### PR TITLE
Changes to make it work with RN v56+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,19 +4,23 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.2.3'
+    classpath 'com.android.tools.build:gradle:2.3.3'
   }
 }
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-  compileSdkVersion 25
-  buildToolsVersion "25.0.3"
+  compileSdkVersion safeExtGet('compileSdkVersion', 25)
+  buildToolsVersion safeExtGet('buildToolsVersion', '25.0.3')
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion 22
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 25)
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
Tasks:
- Upgrade `gradle` to version `2.3.3`.
- Use `compileSdkVersion`, `buildToolsVersion`, `minSdkVersion` and `targetSdkVersion` from `ext` of root project.
- Update default `targetSdkVersion` to `25`.

These changes are backward compatible and will still work on previous React Native versions.
Tested on Android 8, 7.1.1 and 7 devices.