### PR TITLE
Update dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
   repositories {
+    google()
     jcenter()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.1.4'
   }
 }
 
@@ -15,12 +16,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-  compileSdkVersion safeExtGet('compileSdkVersion', 25)
-  buildToolsVersion safeExtGet('buildToolsVersion', '25.0.3')
+  compileSdkVersion safeExtGet('compileSdkVersion', 27)
+  buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', 16)
-    targetSdkVersion safeExtGet('targetSdkVersion', 25)
+    targetSdkVersion safeExtGet('targetSdkVersion', 26)
     versionCode 1
     versionName "1.0"
   }
@@ -35,5 +36,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
It seems that common-25.3.3.jar required by com.android.tools.build:gradle:2.3.3 is removed from jcenter recently.
related stackoverflow question: https://stackoverflow.com/questions/53677823/cannot-run-existing-android-project-com-android-toolscommon25-3-3