### PR TITLE
Migrate gradle plugin to version 3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,5 +35,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Fix WARNING:
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.

Quick Reference:
1. https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html