### PR TITLE
Fix Gradle 2.3.3 Build Issues by Updating Repositories and Dependency Configuration

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-  repositories {
-    jcenter()
-  }
-
-  dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
-  }
+	repositories {
+		maven { url 'https://repository.axelor.com/nexus/repository/maven-public/' }
+	}
+	dependencies {
+		classpath 'com.android.tools.build:gradle:2.3.3'
+	}
 }
+
 
 apply plugin: 'com.android.library'
 
@@ -35,5 +35,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
This PR resolves Gradle 2.3.3 build issues by making the following key changes:

1. Updated the Repository URL:
Replaced the `jcenter() `repository with `maven { url 'https://repository.axelor.com/nexus/repository/maven-public/' }` to ensure dependencies can be properly resolved.

2. Migrated from `compile` to `implementation`:
Updated the `com.facebook.react:react-native` dependency to use `implementation` instead of the deprecated `compile` configuration.